### PR TITLE
Use bearer token and endpoints from android app

### DIFF
--- a/src/consts.nim
+++ b/src/consts.nim
@@ -2,9 +2,9 @@
 import uri, sequtils, strutils
 
 const
-  auth* = "Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
+  auth* = "Bearer AAAAAAAAAAAAAAAAAAAAAFXzAwAAAAAAMHCxpeSDG1gLNLghVe8d74hl6k4%3DRUMF4xAQLsbeBhTSRrCiQpJtxoGWeyHrDb5te2jpGskWDFW82F"
 
-  api = parseUri("https://api.twitter.com")
+  api = parseUri("https://na.albtls.t.co")
   activate* = $(api / "1.1/guest/activate.json")
 
   photoRail* = api / "1.1/statuses/media_timeline.json"


### PR DESCRIPTION
who knows how long this holds but it seems the combination of
cookie+csrf headers together with the api credentials from android app
are not being heavily rate limited at the moment. it might just be my account though, would apprechiate some independent verification that this actually improves things.

see https://github.com/zedeus/nitter/issues/919
