### PR TITLE
tag images by SHA as well

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           images: |
             ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=master
           
 
       - name: Build and push all platforms Docker image


### PR DESCRIPTION
it is currently not possible to pin image references in docker-compose by SHA, as old images become unreferencable as new commits are pushed to master