### PR TITLE
Fix GH action ARM64 docker image

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -46,11 +46,11 @@ jobs:
           images: |
             ghcr.io/${{ env.IMAGE_NAME }}
           
-      - name: set lower case repo name
+      - name: set lower case owner name
         run: |
-          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
         env:
-          REPO: '${{ github.repository }}'
+          OWNER: '${{ github.repository_owner }}'
 
       - name: Build and push amd64 Docker image
         id: build-and-push-amd64
@@ -59,7 +59,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ env.REPO_LC }}:master,ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
+          tags: ${{ env.OWNER_LC }}/nitter:master,${{ env.OWNER_LC }}/nitter:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
@@ -72,7 +72,7 @@ jobs:
           context: .
           file: ./Dockerfile.arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ env.REPO_LC }}:master-arm64,ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}-arm64
+          tags: ${{ env.OWNER_LC }}/nitter-arm64:master,${{ env.OWNER_LC }}/nitter-arm64:${{ github.sha }}-arm64
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64
           cache-from: type=gha

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -59,7 +59,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REPO_LC }}:master,${{ env.REPO_LC }}:${{ github.sha }}
+          tags: ghcr.io/${{ env.REPO_LC }}:master,ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
@@ -72,7 +72,7 @@ jobs:
           context: .
           file: ./Dockerfile.arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REPO_LC }}:master-arm64,${{ env.REPO_LC }}:${{ github.sha }}-arm64
+          tags: ghcr.io/${{ env.REPO_LC }}:master-arm64,ghcr.io/${{ env.REPO_LC }}:${{ github.sha }}-arm64
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64
           cache-from: type=gha

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -54,7 +54,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: PrivacyDevel/nitter:master,PrivacyDevel/nitter:${{ github.sha }}
+          tags: ${{ env.IMAGE_NAME }}:master,${{ env.IMAGE_NAME }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
@@ -67,7 +67,7 @@ jobs:
           context: .
           file: ./Dockerfile.arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: PrivacyDevel/nitter:master-arm64,PrivacyDevel/nitter:${{ github.sha }}-arm64
+          tags: ${{ env.IMAGE_NAME }}:master-arm64,${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64
           cache-from: type=gha

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -47,14 +47,28 @@ jobs:
             ghcr.io/${{ env.IMAGE_NAME }}
           
 
-      - name: Build and push all platforms Docker image
+      - name: Build and push amd64 Docker image
         id: build-and-push
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: PrivacyDevel/nitter:master,PrivacyDevel/nitter:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push arm64 Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: PrivacyDevel/nitter:master-arm64,PrivacyDevel/nitter:${{ github.sha }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -48,7 +48,7 @@ jobs:
           
 
       - name: Build and push amd64 Docker image
-        id: build-and-push
+        id: build-and-push-amd64
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -61,7 +61,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push arm64 Docker image
-        id: build-and-push
+        id: build-and-push-arm64
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -46,6 +46,11 @@ jobs:
           images: |
             ghcr.io/${{ env.IMAGE_NAME }}
           
+      - name: set lower case repo name
+        run: |
+          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
+        env:
+          REPO: '${{ github.repository }}'
 
       - name: Build and push amd64 Docker image
         id: build-and-push-amd64
@@ -54,7 +59,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.IMAGE_NAME }}:master,${{ env.IMAGE_NAME }}:${{ github.sha }}
+          tags: ${{ env.REPO_LC }}:master,${{ env.REPO_LC }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
@@ -67,7 +72,7 @@ jobs:
           context: .
           file: ./Dockerfile.arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.IMAGE_NAME }}:master-arm64,${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
+          tags: ${{ env.REPO_LC }}:master-arm64,${{ env.REPO_LC }}:${{ github.sha }}-arm64
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64
           cache-from: type=gha


### PR DESCRIPTION
The published ARM64 docker image does not seem to work. It looks like in this repo the `Dockerfile.arm64` file was not used to build the ARM64 docker image, causing the failure.

This PR is to use the `Dockerfile.arm64` for building the ARM64 docker image and tag the image similarly to upstream, e.g. `PrivacyDevel/nitter:master-arm64`